### PR TITLE
Fix opt check for dependency

### DIFF
--- a/src/arch/zx48k/optimizer/patterns.py
+++ b/src/arch/zx48k/optimizer/patterns.py
@@ -32,3 +32,6 @@ RE_ID = re.compile(r'[.a-zA-Z_][.a-zA-Z_0-9]*')
 
 # matches a pragma line
 RE_PRAGMA = re.compile(r'^#[ \t]?pragma[ \t]opt[ \t]')
+
+# matches an ID or a number
+RE_ID_OR_NUMBER = re.compile(r'[0-9]+|[a-zA-Z_][a-zA-Z_0-9]*')

--- a/src/arch/zx48k/peephole/evaluator.py
+++ b/src/arch/zx48k/peephole/evaluator.py
@@ -137,8 +137,8 @@ class Evaluator(object):
             || (or)
             +  (addition or concatenation for strings)
     """
-    UNARY = UNARY
-    BINARY = BINARY
+    UNARY = dict(UNARY)
+    BINARY = dict(BINARY)
 
     def __init__(self, expression, unary=None, binary=None):
         """ Initializes the object parsing the expression and preparing it for its (later)

--- a/tests/arch/zx48k/optimizer/test_basicblock.py
+++ b/tests/arch/zx48k/optimizer/test_basicblock.py
@@ -3,13 +3,17 @@
 import unittest
 from src.arch.zx48k.optimizer import basicblock
 from src.arch.zx48k import optimizer
+from src.arch.zx48k.peephole import evaluator
 
 
 class TestBasicBlock(unittest.TestCase):
     """ Tests basic blocks implementation
     """
-    def setUp(self):
+    def setUp(self) -> None:
         self.blk = basicblock.BasicBlock([])
+
+    def tearDown(self) -> None:
+        evaluator.Evaluator.UNARY = dict(evaluator.UNARY)
 
     def test_block_partition_jp(self):
         code = """
@@ -157,3 +161,11 @@ class TestBasicBlock(unittest.TestCase):
         self.blk.code = [x for x in code.split('\n') if x.strip()]
         self.assertEqual(1, len(self.blk))
         self.assertEqual(['ld hl, (30000)'], self.blk.code)
+
+    def test_mempos_requires(self):
+        code = """
+        ld hl, (_k - 1)
+        ld (_k), a
+        """
+        self.blk.code = [x for x in code.split('\n') if x.strip()]
+        self.assertTrue(self.blk.is_used(['(_k)'], 0))

--- a/tests/functional/opt4_due_0.asm
+++ b/tests/functional/opt4_due_0.asm
@@ -1,0 +1,51 @@
+	org 32768
+__START_PROGRAM:
+	di
+	push ix
+	push iy
+	exx
+	push hl
+	exx
+	ld hl, 0
+	add hl, sp
+	ld (__CALL_BACK__), hl
+	ei
+	jp __MAIN_PROGRAM__
+ZXBASIC_USER_DATA:
+	; Defines USER DATA Length in bytes
+ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_END - ZXBASIC_USER_DATA
+	.__LABEL__.ZXBASIC_USER_DATA_LEN EQU ZXBASIC_USER_DATA_LEN
+	.__LABEL__.ZXBASIC_USER_DATA EQU ZXBASIC_USER_DATA
+_k:
+	DEFB 05h
+_n:
+	DEFB 00
+ZXBASIC_USER_DATA_END:
+__MAIN_PROGRAM__:
+	ld a, (_k)
+	xor 31
+	ld (_k), a
+	ld a, (_n)
+	add a, a
+	add a, a
+	add a, a
+	add a, a
+	add a, a
+	ld hl, (_k - 1)
+	or h
+	ld (_k), a
+	ld bc, 0
+__END_PROGRAM:
+	di
+	ld hl, (__CALL_BACK__)
+	ld sp, hl
+	exx
+	pop hl
+	pop iy
+	pop ix
+	exx
+	ei
+	ret
+__CALL_BACK__:
+	DEFW 0
+	END

--- a/tests/functional/opt4_due_0.bas
+++ b/tests/functional/opt4_due_0.bas
@@ -1,0 +1,9 @@
+
+
+DIM k as UByte = 5
+DIM n as UByte
+
+k = k bXOR %11111
+k = (n << 5) bOR k
+
+


### PR DESCRIPTION
When a memory access is of type (a * b + c...) etc,
it will check if any of a, b, c is used and mark them as
required to avoid bypassing dependencies.